### PR TITLE
Enable direct TypeScript test execution with Node.js `--experimental-strip-types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "tar": "^7.0.0"
       },
       "devDependencies": {
+        "@power-assert/node": "^0.5.0",
         "@types/node": "^22.0.0",
         "neostandard": "^0.12.0",
         "rimraf": "^6.0.0",
@@ -376,6 +377,55 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@power-assert/node": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@power-assert/node/-/node-0.5.0.tgz",
+      "integrity": "sha512-2bRfRcLdCUGzCYH5NlWfOOmTbXsLsMrfN1p0DTwmuGHIgJcwd9lD2XGCvFBhA5bVh/VnlZjZ1NQRCxc7g1h1Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@power-assert/transpiler": "^0.5.2"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      },
+      "peerDependencies": {
+        "@power-assert/runtime": "^0.2.1"
+      }
+    },
+    "node_modules/@power-assert/runtime": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@power-assert/runtime/-/runtime-0.2.1.tgz",
+      "integrity": "sha512-6jeuAFVzl4EDoG4hmw76ZG2P/jsRCKvE0PwKS0+tvkCs9XEXEo8p2aq+tz5zXRliSQuMgsK8VuZBMxATQZezhA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@power-assert/transpiler": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@power-assert/transpiler/-/transpiler-0.5.2.tgz",
+      "integrity": "sha512-sMAMLLneaETJgB0j1C4sbUQ0EmYGoVbma6cUr7hvZwoI3nOpCgyAVzAYU0SrYwCWS+z9zUXXy7SgjpJpGWrkhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@power-assert/transpiler-core": "^0.4.1",
+        "acorn": "^8.14.0",
+        "astring": "^1.9.0",
+        "convert-source-map": "^2.0.0",
+        "multi-stage-sourcemap": "^0.3.1",
+        "source-map": "^0.7.4"
+      }
+    },
+    "node_modules/@power-assert/transpiler-core": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@power-assert/transpiler-core/-/transpiler-core-0.4.2.tgz",
+      "integrity": "sha512-WfUBGDSNXlvZHeY5acMTQEQc8A/W+NxsNdTCTf/k7bd91TnbQqapO7OcPEjdateaFGbMwimkq+5APBl4g/N0xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^3.0.3"
+      }
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
@@ -412,8 +462,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -972,6 +1021,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "license": "BSD-3-Clause OR MIT",
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -1145,6 +1204,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/async-function": {
@@ -1326,6 +1395,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2144,6 +2220,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -3413,6 +3499,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/multi-stage-sourcemap": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.3.1.tgz",
+      "integrity": "sha512-UiTLYjqeIoVnJHyWGskwMKIhtZKK9uXUjSTWuwatarrc0d2H/6MAVFdwvEA/aKOHamIn7z4tfvxjz+FYucFpNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.1.34"
+      }
+    },
+    "node_modules/multi-stage-sourcemap/node_modules/source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+      "dev": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
@@ -4180,6 +4288,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/stable-hash": {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,15 @@
     "compile": "tsc",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "test:dist": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
-    "test:unit": "node --experimental-strip-types --enable-source-maps --test \"./src/__tests__/*test.mts\"",
+    "test:dist": "node --enable-source-maps --import @power-assert/node --test \"./dist/__tests__/*test.mjs\"",
+    "test:unit": "node --experimental-strip-types --enable-source-maps --import @power-assert/node --test \"./src/__tests__/*test.mts\"",
     "test": "npm run lint && npm run test:unit"
   },
   "dependencies": {
     "tar": "^7.0.0"
   },
   "devDependencies": {
+    "@power-assert/node": "^0.5.0",
     "@types/node": "^22.0.0",
     "neostandard": "^0.12.0",
     "rimraf": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -42,13 +42,15 @@
     "package.json"
   ],
   "scripts": {
-    "preversion": "npm test",
+    "rebuild": "npm run clean && npm run lint && npm run compile && npm run test:dist",
+    "preversion": "npm run rebuild",
     "clean": "rimraf dist",
-    "build": "tsc",
+    "compile": "tsc",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "test:unit": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
-    "test": "npm run clean && npm run lint && npm run build && npm run test:unit"
+    "test:dist": "node --enable-source-maps --test \"./dist/__tests__/*test.mjs\"",
+    "test:unit": "node --experimental-strip-types --enable-source-maps --test \"./src/__tests__/*test.mts\"",
+    "test": "npm run lint && npm run test:unit"
   },
   "dependencies": {
     "tar": "^7.0.0"

--- a/src/__tests__/exists_test.mts
+++ b/src/__tests__/exists_test.mts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
-import { exists } from '../index.mjs';
+import { exists } from '../index.mts';
 import { strict as assert } from 'node:assert';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';

--- a/src/__tests__/extract_test.mts
+++ b/src/__tests__/extract_test.mts
@@ -1,4 +1,4 @@
-import { extract } from '../index.mjs';
+import { extract } from '../index.mts';
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { tmpdir } from 'node:os';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "es2022",
+    "target": "esnext",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
     // any imports or exports without a type modifier are left around
     "verbatimModuleSyntax": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
-    "lib": ["es2022"]
+    "lib": ["esnext"]
   },
   "include": ["./src/**/*.ts", "./src/**/*.mts"]
 }


### PR DESCRIPTION
This PR modernizes the development workflow by leveraging Node.js's `--experimental-strip-types` flag to run TypeScript tests directly without compilation.

##  Changes

- Improved development workflow: Tests can now run directly on TypeScript source files using `npm run test:unit` with the `--experimental-strip-types` flag
- Power Assert integration: Added [@power-assert/node](https://github.com/twada/power-assert-monorepo/tree/main/packages/node) for more informative test failure messages
- Improved build scripts:
  - Renamed `build` → `compile` for clarity
  - `npm run rebuild` performs a full build cycle (clean, lint, compile, test distribution)
  - Separated development testing (`npm test`) from distribution testing (`npm run test:dist`)
    - `npm test` now runs linting and TypeScript source tests for rapid development feedback
    - `npm run test:dist` tests the compiled JavaScript distribution
- Updated TypeScript configuration:
  - Enabled `rewriteRelativeImportExtensions` to properly handle ESM imports during compilation
  - Enabled `erasableSyntaxOnly` for compatibility with type stripping
  - Changed target from `es2022` to `esnext` to leverage latest JavaScript features
- Updated import paths: Updated test imports to use `.mts` extensions for TypeScript source files

##  Benefits

- Faster development cycle: No compilation step needed for running tests during development
- Better developer experience: Immediate feedback with source-mapped errors and power-assert diagnostics
- Maintained compatibility: Distribution builds and tests ensure the published package works correctly
- Aligns with Node.js's evolving TypeScript support